### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A Model Context Protocol (MCP) server for the Mews hospitality platform API. This server provides comprehensive access to Mews operations through a standardized interface.
 
+<a href="https://glama.ai/mcp/servers/@code-rabi/mews-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@code-rabi/mews-mcp/badge" alt="Mews MCP server" />
+</a>
+
 ## Overview
 
 This MCP server provides comprehensive access to the Mews hospitality platform API, covering customer and company management, reservation operations, financial transactions, account management, configuration settings, and services inventory. It implements the core functionality needed for hospitality management through a standardized Model Context Protocol interface.
@@ -48,4 +52,4 @@ To work directly with the published package, copy the following JSON and paste i
 
 ## License
 
-MIT License - see LICENSE file for details. 
+MIT License - see LICENSE file for details.


### PR DESCRIPTION
This PR adds a badge for the [Mews MCP](https://glama.ai/mcp/servers/@code-rabi/mews-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@code-rabi/mews-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@code-rabi/mews-mcp/badge" alt="Mews MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.